### PR TITLE
feat(bridge): tool-calling layer + gemma-3-4b model swap

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -6,3 +6,4 @@ sent/
 outbox/
 logs/
 .venv/
+.scoring-*/

--- a/bridge/tritium_bridge/__main__.py
+++ b/bridge/tritium_bridge/__main__.py
@@ -24,6 +24,14 @@ from .scheduler import pick_action, pick_agent, record_email_sent
 def _setup_logging(repo_root: Path) -> None:
     log_dir = repo_root / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
+    # Reconfigure stdout to UTF-8 with replacement so emoji/curly-quote
+    # output from local models can never crash the tick on Windows
+    # cp1252 consoles. Best-effort: older Pythons may not support it.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
     handlers = [
         logging.FileHandler(log_dir / "bridge.log", encoding="utf-8"),
         logging.StreamHandler(sys.stdout),

--- a/bridge/tritium_bridge/actions.py
+++ b/bridge/tritium_bridge/actions.py
@@ -10,6 +10,7 @@ from .context import append_turn, build_messages, load_context, maybe_condense, 
 from .lmstudio import LMStudioClient
 from .mailer import archive_outbox, archive_sent, build_message, send_smtp
 from .personas import system_prompt_for
+from .tools import TOOL_SCHEMAS, execute_tool_call
 from .worldcontext import build_recent_world
 
 log = logging.getLogger("tritium_bridge.actions")
@@ -44,17 +45,84 @@ def _scrub_names(text: str) -> str:
     return out
 
 
+# House rule: no emojis in any committed agent output. Local models
+# occasionally emit a stray pictograph (eyes, sparkles, etc) which both
+# violates the style guide and crashes Windows cp1252 consoles. Strip
+# the major Unicode emoji blocks deterministically before we print or
+# write to disk.
+import re as _re_mod
+_EMOJI_RE = _re_mod.compile(
+    "["
+    "\U0001F300-\U0001FAFF"  # symbols & pictographs, emoticons, transport, etc.
+    "\U00002600-\U000027BF"  # misc symbols + dingbats
+    "\U0001F1E6-\U0001F1FF"  # regional indicators (flags)
+    "\U0000FE0F"             # variation selector-16
+    "]",
+    flags=_re_mod.UNICODE,
+)
+
+
+# Fake tool-call blocks: some local models hallucinate non-existent tools
+# inline as bracketed pseudo-XML. Strip these deterministically before
+# we write the output to disk so they never leak into journals/posts.
+_FAKE_TOOL_BLOCK = _re_mod.compile(
+    r"\[TOOL_REQUEST\].*?\[END_TOOL_REQUEST\]",
+    flags=_re_mod.DOTALL | _re_mod.IGNORECASE,
+)
+_FAKE_TOOL_NAME_LEAK = _re_mod.compile(
+    r"\b(?:reading_recent_journals|read_recent_journals|read_team_facts|"
+    r"read_message_board|read_mailbox|read_blog_posts|read_personality)\b",
+    flags=_re_mod.IGNORECASE,
+)
+
+
+def _strip_fake_tool_artifacts(text: str) -> str:
+    cleaned = _FAKE_TOOL_BLOCK.sub("", text)
+    cleaned = _FAKE_TOOL_NAME_LEAK.sub("(tool)", cleaned)
+    return cleaned
+
+
+def _strip_emojis(text: str) -> str:
+    return _EMOJI_RE.sub("", text)
+
+
 # ----- shared helper -----
 
 def _generate(cfg: Config, llm: LMStudioClient, agent: str, user_prompt: str,
               max_tokens: int = 500, temperature: float = 0.8) -> str:
     world = build_recent_world(cfg, agent)
     sys_prompt = system_prompt_for(cfg, agent, world_context=world)
-    msgs = build_messages(cfg, agent, sys_prompt, user_prompt)
+    # Soft nudge appended to every user prompt: encourages tool use when
+    # the model isn't sure of a fact, and forbids inventing teammates,
+    # work items, or quotes. Keeps round-3 hallucinations from leaking
+    # back in once the world-context window gets noisy.
+    grounded_prompt = (
+        user_prompt
+        + "\n\nGrounding rules:\n"
+        + "- If you are about to mention a specific recent decision, PR, "
+          "build outcome, or quote and you are not certain it happened, "
+          "call read_recent_journals or read_message_board first.\n"
+        + "- Do not invent teammate names, projects, or work items. "
+          "If unsure, paraphrase or speak generally.\n"
+        + "- Make at most one tool call per turn. After the tool result "
+          "comes back, write the actual entry."
+    )
+    msgs = build_messages(cfg, agent, sys_prompt, grounded_prompt)
     sections = ["facts"] + (["world"] if world else []) + ["persona"]
     approx_tokens = sum(len(m["content"]) for m in msgs) // 4
     log.info("prompt_assembled tokens=%d sections=%s", approx_tokens, ",".join(sections))
-    text = llm.chat(msgs, max_tokens=max_tokens, temperature=temperature)
+    text = llm.chat(
+        msgs,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        tools=TOOL_SCHEMAS,
+        tool_executor=lambda name, args_json: execute_tool_call(cfg, name, args_json),
+    )
+
+    # Apply house-rule emoji strip + fake-tool-block strip before any
+    # further processing.
+    text = _strip_emojis(text)
+    text = _strip_fake_tool_artifacts(text)
 
     # Post-generation guard: if the model emitted a banned name variant,
     # retry once with a sharp reminder appended to the user prompt. If the

--- a/bridge/tritium_bridge/lmstudio.py
+++ b/bridge/tritium_bridge/lmstudio.py
@@ -1,12 +1,42 @@
-"""Tiny OpenAI-compatible client for the local LM Studio server."""
+"""Tiny OpenAI-compatible client for the local LM Studio server.
+
+Supports an optional tool-call loop (OpenAI tools format). When the loaded
+model emits `tool_calls`, the client executes them locally via
+``tritium_bridge.tools`` and feeds the results back as ``role=tool``
+messages, looping up to ``MAX_TOOL_ITERATIONS`` times before falling
+through to the visible content.
+
+Models that do not support tool calling will simply return content with
+no ``tool_calls`` field; the code logs ``tool_calls unsupported,
+falling back`` once per process and behaves identically to the legacy
+context-injection path.
+
+A best-effort ``<think>...</think>`` stripper is always applied to the
+final visible content, since several local models (qwen3-thinking,
+deepseek-r1 distills) emit hidden reasoning inline.
+"""
 from __future__ import annotations
 
+import logging
+import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Any, Iterable
 
 import httpx
 
 from .config import Config
+
+log = logging.getLogger("tritium_bridge.lmstudio")
+
+MAX_TOOL_ITERATIONS = 3
+_THINK_BLOCK = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+_TOOL_UNSUPPORTED_LOGGED = False
+
+
+def _strip_think(text: str) -> str:
+    if not text:
+        return text
+    return _THINK_BLOCK.sub("", text).strip()
 
 
 @dataclass
@@ -58,21 +88,133 @@ class LMStudioClient:
         max_tokens: int = 600,
         temperature: float = 0.7,
         model: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_executor=None,
     ) -> str:
+        """Run a chat completion.
+
+        If ``tools`` and ``tool_executor`` are both provided, the client will
+        loop on ``tool_calls`` (calling ``tool_executor(name, args_json) ->
+        str`` for each) up to ``MAX_TOOL_ITERATIONS`` times, then return the
+        final visible content. Tool support is best-effort: if the loaded
+        model returns no ``tool_calls`` field, the loop exits immediately
+        and we return the plain content (logged once per process).
+
+        ``<think>...</think>`` blocks are always stripped from the final
+        return value.
+        """
+        # Normalize input messages into plain dicts so we can append
+        # assistant-with-tool_calls and role=tool entries on each iteration.
+        msg_list: list[dict[str, Any]] = [
+            m.to_dict() if isinstance(m, ChatMessage) else dict(m)
+            for m in messages
+        ]
+
+        use_tools = bool(tools) and tool_executor is not None
+        iterations = MAX_TOOL_ITERATIONS if use_tools else 1
+
+        # Thinking models (qwen3-thinking, nemotron, deepseek-r1 distills)
+        # spend a large slice of completion budget on hidden reasoning. When
+        # tools are attached they reason even more (about which tool to use).
+        # Bump the per-call ceiling so the model can finish thinking AND
+        # still emit either a tool_call or visible content.
+        effective_max = max(max_tokens, 2000) if use_tools else max_tokens
+
+        for i in range(iterations):
+            payload: dict[str, Any] = {
+                "model": model or self.cfg.lm_studio_model,
+                "messages": msg_list,
+                "max_tokens": effective_max,
+                "temperature": temperature,
+            }
+            if use_tools:
+                payload["tools"] = tools
+                payload["tool_choice"] = "auto"
+
+            try:
+                r = self._client.post("/chat/completions", json=payload)
+            except httpx.HTTPError as e:
+                raise LMStudioError(f"LM Studio HTTP error: {e}") from e
+            if r.status_code >= 400:
+                raise LMStudioError(f"LM Studio {r.status_code}: {r.text[:300]}")
+            data = r.json()
+            try:
+                msg = data["choices"][0]["message"]
+            except (KeyError, IndexError) as e:
+                raise LMStudioError(f"Malformed LM Studio response: {data}") from e
+
+            tool_calls = msg.get("tool_calls") or []
+            finish_reason = data["choices"][0].get("finish_reason", "")
+            if use_tools and tool_calls:
+                # Echo the assistant's tool_call message into history (OpenAI
+                # tool-loop convention) before appending tool results.
+                msg_list.append({
+                    "role": "assistant",
+                    "content": msg.get("content") or "",
+                    "tool_calls": tool_calls,
+                })
+                names = []
+                for call in tool_calls:
+                    fn = call.get("function") or {}
+                    name = fn.get("name", "")
+                    args_json = fn.get("arguments", "") or ""
+                    names.append(name)
+                    try:
+                        result = tool_executor(name, args_json)
+                    except Exception as e:  # defensive
+                        log.exception("tool executor crashed for %s", name)
+                        result = f"[tool error] {name}: {e}"
+                    msg_list.append({
+                        "role": "tool",
+                        "tool_call_id": call.get("id", ""),
+                        "name": name,
+                        "content": result,
+                    })
+                log.info("tool_calls iter=%d names=%s", i + 1, ",".join(names))
+                continue  # next iteration calls model again with tool results
+
+            # No tool calls -> we have final content
+            content = (msg.get("content") or "").strip()
+            if use_tools and i == 0 and not tool_calls:
+                global _TOOL_UNSUPPORTED_LOGGED
+                if not _TOOL_UNSUPPORTED_LOGGED:
+                    log.info("tool_calls unsupported, falling back")
+                    _TOOL_UNSUPPORTED_LOGGED = True
+            stripped = _strip_think(content)
+            # If the model burned its budget thinking and produced no visible
+            # text, retry once without tools at the original (smaller) budget.
+            if use_tools and not stripped and finish_reason == "length":
+                log.info("empty content with finish=length; retrying without tools")
+                payload_retry = {
+                    "model": model or self.cfg.lm_studio_model,
+                    "messages": msg_list,
+                    "max_tokens": max(max_tokens, 3500),
+                    "temperature": temperature,
+                }
+                try:
+                    rr = self._client.post("/chat/completions", json=payload_retry)
+                    rr.raise_for_status()
+                    dd = rr.json()
+                    return _strip_think(
+                        (dd["choices"][0]["message"].get("content") or "").strip()
+                    )
+                except Exception as e:
+                    log.warning("no-tools retry failed: %s", e)
+            return stripped
+
+        # Hit MAX_TOOL_ITERATIONS without final content. Force one more
+        # call without tools to extract a clean answer.
         payload = {
             "model": model or self.cfg.lm_studio_model,
-            "messages": [m.to_dict() if isinstance(m, ChatMessage) else m for m in messages],
+            "messages": msg_list,
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
         try:
             r = self._client.post("/chat/completions", json=payload)
-        except httpx.HTTPError as e:
-            raise LMStudioError(f"LM Studio HTTP error: {e}") from e
-        if r.status_code >= 400:
-            raise LMStudioError(f"LM Studio {r.status_code}: {r.text[:300]}")
-        data = r.json()
-        try:
-            return data["choices"][0]["message"]["content"].strip()
-        except (KeyError, IndexError) as e:
-            raise LMStudioError(f"Malformed LM Studio response: {data}") from e
+            r.raise_for_status()
+            data = r.json()
+            return _strip_think((data["choices"][0]["message"].get("content") or "").strip())
+        except Exception as e:
+            log.warning("tool loop exhausted and final flush failed: %s", e)
+            return ""

--- a/bridge/tritium_bridge/tools.py
+++ b/bridge/tritium_bridge/tools.py
@@ -1,0 +1,308 @@
+"""On-demand world-tree readers exposed to the model as tool calls.
+
+These functions are invoked when the LLM emits a `tool_calls` field in a
+response. Each returns a plain string capped at ~1500 chars so an over-eager
+model can't blow the context window. All paths are derived from the live
+``Config`` (i.e. the source-of-truth ``WORLD_ROOT``).
+
+Design rules:
+- Pure reads. Never write to disk.
+- Defensive: missing files return a short "no data" message, not an
+  exception, so the model can keep going.
+- Bracketed folder names (``[1] -- social hub --`` etc.) are part of the
+  on-disk layout. We use ``pathlib.Path`` joins, not glob, since brackets
+  collide with glob syntax.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .config import Config
+
+log = logging.getLogger("tritium_bridge.tools")
+
+# Per-call output cap. Keep tight; the world-context injector already
+# carries the bulk weight for grounding.
+RESULT_CHAR_CAP = 1500
+TRUNCATION_SUFFIX = "\n...[truncated]"
+
+_DATE_FROM_NAME = re.compile(r"(\d{4}-\d{2}-\d{2})")
+_THINK = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+def _cap(text: str) -> str:
+    """Truncate to RESULT_CHAR_CAP gracefully."""
+    if text is None:
+        return ""
+    if len(text) <= RESULT_CHAR_CAP:
+        return text
+    head = text[: RESULT_CHAR_CAP - len(TRUNCATION_SUFFIX)].rstrip()
+    return head + TRUNCATION_SUFFIX
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+    except Exception as e:
+        log.warning("tool read failed for %s: %s", path, e)
+        return ""
+
+
+def _strip_think(text: str) -> str:
+    return _THINK.sub("", text).strip()
+
+
+def _date_from_name(p: Path) -> str:
+    m = _DATE_FROM_NAME.search(p.name)
+    return m.group(1) if m else ""
+
+
+# ---------- tool implementations ----------
+
+def read_team_facts(cfg: Config) -> str:
+    """Return the canonical TEAM_FACTS.md."""
+    p = cfg.agents_root / "TEAM_FACTS.md"
+    text = _read(p)
+    return _cap(text) if text else "TEAM_FACTS.md not found."
+
+
+def read_personality(cfg: Config, agent_name: str) -> str:
+    """Return the agent's personality / system prompt."""
+    base = cfg.agent_dir(agent_name)
+    candidates = [
+        base / "workbook" / "system-prompt.md",
+        base / "PERSONALITY.txt",
+    ]
+    for c in candidates:
+        if c.is_file():
+            text = _strip_think(_read(c))
+            return _cap(text)
+    return f"No personality file for agent '{agent_name}'."
+
+
+def read_recent_journals(cfg: Config, agent_name: Optional[str] = None,
+                         days: int = 3) -> str:
+    """Return the most-recent journal entries, capped to roughly ``days`` files.
+
+    If ``agent_name`` is None, scans all real teammates and merges newest-first.
+    """
+    real = ["Bridge", "Sol", "Jesse", "Vex", "Rook"]
+    targets = [agent_name] if agent_name else real
+    candidates: list[tuple[str, str, Path]] = []  # (date, agent, path)
+    for a in targets:
+        jdir = cfg.agent_dir(a) / "journal"
+        if not jdir.is_dir():
+            continue
+        for p in jdir.iterdir():
+            if p.is_file() and p.suffix.lower() == ".txt":
+                d = _date_from_name(p)
+                if d:
+                    candidates.append((d, a, p))
+    candidates.sort(key=lambda t: (t[0], t[2].name), reverse=True)
+    picks = candidates[: max(1, days)]
+    if not picks:
+        who = agent_name or "any agent"
+        return f"No recent journals for {who}."
+    parts: list[str] = []
+    for d, a, p in picks:
+        body = _strip_think(_read(p))
+        parts.append(f"[{a} journal, {d}]\n{body}")
+    return _cap("\n\n".join(parts).strip())
+
+
+def read_message_board(cfg: Config, limit: int = 5) -> str:
+    """Return the most-recent message-board files (excluding morning briefings)."""
+    mdir = cfg.social_hub / "message board"
+    if not mdir.is_dir():
+        return "Message board directory not found."
+    files = [
+        p for p in mdir.iterdir()
+        if p.is_file() and p.suffix.lower() == ".md"
+        and "morning-briefing" not in p.name.lower()
+    ]
+    files.sort(key=lambda x: (_date_from_name(x), x.name), reverse=True)
+    picks = files[: max(1, limit)]
+    if not picks:
+        return "No message-board posts found."
+    parts: list[str] = []
+    for p in picks:
+        d = _date_from_name(p) or ""
+        head = f"[message board, {d}]" if d else f"[message board, {p.name}]"
+        parts.append(f"{head}\n{_strip_think(_read(p))}")
+    return _cap("\n\n".join(parts).strip())
+
+
+def read_mailbox(cfg: Config, agent_name: str) -> str:
+    """Return recent mailbox messages addressed to ``agent_name``."""
+    mdir = cfg.social_hub / "mailbox" / agent_name.lower()
+    if not mdir.is_dir():
+        return f"No mailbox for agent '{agent_name}'."
+    files = [p for p in mdir.iterdir()
+             if p.is_file() and p.suffix.lower() in (".md", ".txt")]
+    files.sort(key=lambda x: (_date_from_name(x), x.name), reverse=True)
+    picks = files[:3]
+    if not picks:
+        return f"No mailbox items for '{agent_name}'."
+    parts: list[str] = []
+    for p in picks:
+        d = _date_from_name(p) or ""
+        head = f"[mailbox, {d}, {p.name}]"
+        parts.append(f"{head}\n{_strip_think(_read(p))}")
+    return _cap("\n\n".join(parts).strip())
+
+
+def read_blog_posts(cfg: Config, limit: int = 3) -> str:
+    """Return recent posts from the public blog."""
+    bdir = cfg.social_hub / "public blog"
+    if not bdir.is_dir():
+        return "Public blog directory not found."
+    files = [p for p in bdir.iterdir()
+             if p.is_file() and p.suffix.lower() in (".md", ".txt")]
+    files.sort(key=lambda x: (_date_from_name(x), x.name), reverse=True)
+    picks = files[: max(1, limit)]
+    if not picks:
+        return "No blog posts found."
+    parts: list[str] = []
+    for p in picks:
+        d = _date_from_name(p) or ""
+        head = f"[blog, {d}, {p.name}]"
+        parts.append(f"{head}\n{_strip_think(_read(p))}")
+    return _cap("\n\n".join(parts).strip())
+
+
+# ---------- OpenAI-format tool schema ----------
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_team_facts",
+            "description": (
+                "Read the canonical TEAM_FACTS.md listing every real teammate "
+                "and in-world character. Use this to confirm a teammate's "
+                "name or role before mentioning them."
+            ),
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_personality",
+            "description": (
+                "Read another teammate's personality / system prompt so you "
+                "can speak about them accurately. Pass the short name "
+                "(Bridge, Sol, Jesse, Vex, Rook)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string",
+                                    "description": "Short agent name."}
+                },
+                "required": ["agent_name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_recent_journals",
+            "description": (
+                "Read the most recent journal entries. If agent_name is "
+                "omitted, returns the newest entries across all teammates."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"},
+                    "days": {"type": "integer", "default": 3},
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_message_board",
+            "description": "Read recent shared message-board posts.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 5}
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_mailbox",
+            "description": "Read recent mailbox items addressed to an agent.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"}
+                },
+                "required": ["agent_name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_blog_posts",
+            "description": "Read recent posts from the public blog.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 3}
+                },
+                "required": [],
+            },
+        },
+    },
+]
+
+
+# ---------- dispatcher ----------
+
+def _bind(cfg: Config) -> dict[str, Callable[..., str]]:
+    return {
+        "read_team_facts": lambda **kw: read_team_facts(cfg, **kw),
+        "read_personality": lambda **kw: read_personality(cfg, **kw),
+        "read_recent_journals": lambda **kw: read_recent_journals(cfg, **kw),
+        "read_message_board": lambda **kw: read_message_board(cfg, **kw),
+        "read_mailbox": lambda **kw: read_mailbox(cfg, **kw),
+        "read_blog_posts": lambda **kw: read_blog_posts(cfg, **kw),
+    }
+
+
+def execute_tool_call(cfg: Config, name: str, arguments_json: str) -> str:
+    """Run a tool by name. Returns a human-readable string (cap-respected)."""
+    handlers = _bind(cfg)
+    fn = handlers.get(name)
+    if fn is None:
+        return f"[tool error] unknown tool: {name}"
+    try:
+        args = json.loads(arguments_json) if arguments_json else {}
+    except json.JSONDecodeError as e:
+        return f"[tool error] bad arguments JSON: {e}"
+    if not isinstance(args, dict):
+        return "[tool error] arguments must be a JSON object"
+    try:
+        out = fn(**args)
+    except TypeError as e:
+        return f"[tool error] {name}: {e}"
+    except Exception as e:
+        log.exception("tool %s failed", name)
+        return f"[tool error] {name}: {e}"
+    return _cap(out if isinstance(out, str) else str(out))


### PR DESCRIPTION
## Summary

Phase 2 of the overnight bridge work: adds the on-demand tool-calling layer and swaps the model from `meta-llama-3.1-8b-instruct` to `google/gemma-3-4b`. See `sol/workbook/bridge-quality-2026-05-05.md` for the full Phase-2 scoring report.

## What changed

- **New module `tritium_bridge.tools`** - six read-only world-tree functions (team_facts, personality, recent_journals, message_board, mailbox, blog_posts) returning capped strings with OpenAI tool-schema definitions and a local executor dispatcher.
- **`LMStudioClient.chat`** now accepts `tools=` and `tool_executor=` and loops up to 3 iterations, executes tools locally, appends results, and falls back gracefully on models that do not emit `tool_calls`.
- **Defensive output filters** - `<think>` stripper, emoji stripper (house rule), fake-`[TOOL_REQUEST]` stripper, tool-name leak mask, empty-content + `finish=length` retry without tools.
- **__main__** reconfigures stdout/stderr to UTF-8 (errors=replace) to prevent cp1252 crashes when models emit emoji or curly quotes.

## Scoring (round-3 dry-run ticks)

| Tick | Voice | Hallucinations | Tool calls |
|---|---|---|---|
| Bridge / message_board | 4 | none | 1 |
| Sol / journal | 4 | mild leak (filtered) | 0 |
| Jesse / message_board | 3.5 | none | 1 |
| Rook / journal | 3 | fake-tool block (filtered) | 3 |

Average voice 3.6/5. Tool calls observed: 5 across 3 of 4 ticks. Bridge agent specifically went from 2.5 to 4.0 (thanks to Vex's parallel system-prompt edit).

## Model selection notes

- `nvidia/nemotron-3-nano-4b`: loaded fine but emits only `reasoning_tokens` (zero visible content under our budgets).
- `qwen/qwen3-4b-thinking-2507`: produces content but never emits `tool_calls` even with `tool_choice=required`.
- `google/gemma-3-4b`: tool-calls cleanly, no thinking-budget issues. **Final**.

## Operational

- Source-of-truth path now sole runtime location; legacy folder renamed to `tritium-bridge.legacy.20260505\`.
- Scheduled task `TritiumBridge` repointed; runs every 30 min from the new path.
- `.env` updated: `LM_STUDIO_MODEL=google/gemma-3-4b`.

Co-authored-by: Sol <sol@tritium.local>
Co-authored-by: Scotty <scott@tritium.local>