### PR TITLE
feat: Add global template caching, global install support, and tritium init command

### DIFF
--- a/runtime/cli/tritium.js
+++ b/runtime/cli/tritium.js
@@ -71,6 +71,7 @@ function help() {
   console.log(`tritium 0.1.0
 usage:
   tritium serve
+  tritium init [--target <path>] [--force]     - initialize team workflow in a project.
   tritium inbox check [--agent <name>] [--all]
   tritium send-im --from <a> --to <b> --body "..." [--subject "..."]
   tritium send-email --from <a> --to <b> --subject "..." --body "..." [--attach <path>]
@@ -78,7 +79,7 @@ usage:
   tritium agents
   tritium status
 
-The runtime must be running for inbox/send commands. Start it with: tritium serve
+The runtime must be running for inbox/send/agents commands. Start it with: tritium serve
 `);
 }
 
@@ -102,6 +103,26 @@ const args = parseArgs(process.argv.slice(3));
       const child = spawn(process.execPath, [path.join(ROOT, 'runtime', 'server', 'src', 'index.js')], {
         stdio: 'inherit',
         cwd: path.join(ROOT, 'runtime', 'server'),
+      });
+      child.on('exit', (code) => process.exit(code ?? 0));
+      break;
+    }
+
+    case 'init':
+    case 'setup': {
+      const target = args.target || args._[0] || '.';
+      const isWindows = process.platform === 'win32';
+      const scriptName = isWindows ? 'setup-team.ps1' : 'setup-team.sh';
+      const scriptPath = path.join(ROOT, 'scripts', scriptName);
+      
+      const shellCmd = isWindows ? 'powershell' : 'bash';
+      const procArgs = isWindows 
+        ? ['-File', scriptPath, '-Target', target, args.force ? '-Force' : '']
+        : [scriptPath, '--target', target, args.force ? '--force' : ''];
+      
+      const child = spawn(shellCmd, procArgs.filter(Boolean), {
+        stdio: 'inherit',
+        shell: true,
       });
       child.on('exit', (code) => process.exit(code ?? 0));
       break;

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -202,6 +202,36 @@ function Copy-One ([string]$name) {
 }
 foreach ($s in ($v41 + $helpers)) { Copy-One $s }
 
+# --- templates -------------------------------------------------------------
+Write-Log ''
+Write-Log "[3.5/5] Consolidating templates -> $tritiumHome\templates"
+$templatesDir = Join-Path $tritiumHome 'templates'
+if (-not (Test-Path $templatesDir)) {
+    if (-not $DryRun) { New-Item -ItemType Directory -Path $templatesDir -Force | Out-Null }
+}
+
+function Copy-TemplateDir ([string]$folder) {
+    $src = Join-Path $repoRoot $folder
+    $dst = Join-Path $templatesDir $folder
+    if (-not (Test-Path $src)) { return }
+    Write-Log "  copy template: $folder"
+    if (-not $DryRun) {
+        if (Test-Path $dst) { Remove-Item -Recurse -Force $dst }
+        Copy-Item -Path $src -Destination $dst -Recurse -Force
+    }
+}
+
+Copy-TemplateDir "agents"
+Copy-TemplateDir "world"
+Copy-TemplateDir "adapters"
+
+$settingsSrc = Join-Path $repoRoot "SETTINGS.example.jsonc"
+$settingsDst = Join-Path $templatesDir "SETTINGS.example.jsonc"
+if (Test-Path $settingsSrc) {
+    Write-Log "  copy template: SETTINGS.example.jsonc"
+    if (-not $DryRun) { Copy-Item $settingsSrc $settingsDst -Force }
+}
+
 # --- mailboxes -------------------------------------------------------------
 Write-Log ''
 Write-Log "[4/5] Agent mailboxes -> $mailboxRoot"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -302,6 +302,39 @@ for s in $V41_SCRIPTS $HELPER_SCRIPTS; do
     _copy_one "$s"
 done
 
+# --- templates --------------------------------------------------------------
+_log ""
+_log "[3.5/5] Consolidating templates -> $TRITIUM_HOME/templates"
+TEMPLATES_DIR="$TRITIUM_HOME/templates"
+if [ "$DRY" -eq 0 ]; then
+    mkdir -p "$TEMPLATES_DIR"
+fi
+
+_copy_template_dir() {
+    local folder="$1"
+    local src="$REPO_ROOT/$folder"
+    local dst="$TEMPLATES_DIR/$folder"
+    if [ ! -d "$src" ]; then
+        return
+    fi
+    _log "  copy template: $folder"
+    if [ "$DRY" -eq 0 ]; then
+        rm -rf "$dst"
+        cp -R "$src" "$dst"
+    fi
+}
+
+_copy_template_dir "agents"
+_copy_template_dir "world"
+_copy_template_dir "adapters"
+
+if [ -f "$REPO_ROOT/SETTINGS.example.jsonc" ]; then
+    _log "  copy template: SETTINGS.example.jsonc"
+    if [ "$DRY" -eq 0 ]; then
+        cp "$REPO_ROOT/SETTINGS.example.jsonc" "$TEMPLATES_DIR/SETTINGS.example.jsonc"
+    fi
+fi
+
 # --- agent mailboxes --------------------------------------------------------
 _log ""
 _log "[4/5] Agent mailboxes -> $MAILBOX_ROOT"

--- a/scripts/setup-team.ps1
+++ b/scripts/setup-team.ps1
@@ -13,6 +13,21 @@ $ErrorActionPreference = 'Stop'
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = (Resolve-Path (Join-Path $here '..')).Path
+$tritiumHome = if ($env:TRITIUM_HOME) { $env:TRITIUM_HOME } else { Join-Path $env:USERPROFILE '.tritium-team' }
+
+# Determine source template paths dynamically
+$repoAgents = Join-Path $repoRoot "agents"
+if (Test-Path $repoAgents) {
+    $srcAgents   = $repoAgents
+    $srcWorld    = Join-Path $repoRoot "world"
+    $srcSettings = Join-Path $repoRoot "SETTINGS.example.jsonc"
+    $srcAdapters = Join-Path $repoRoot "adapters"
+} else {
+    $srcAgents   = Join-Path $tritiumHome "templates\agents"
+    $srcWorld    = Join-Path $tritiumHome "templates\world"
+    $srcSettings = Join-Path $tritiumHome "templates\SETTINGS.example.jsonc"
+    $srcAdapters = Join-Path $tritiumHome "templates\adapters"
+}
 
 if (-not (Test-Path $Target)) {
     New-Item -ItemType Directory -Path $Target -Force | Out-Null
@@ -23,7 +38,7 @@ Write-Host ""
 Write-Host "===================================================================="
 Write-Host "                  TRITIUM TEAM WORKFLOW INITIALIZER                 "
 Write-Host "===================================================================="
-Write-Host "  Source Template : $repoRoot"
+Write-Host "  Source Templates: $srcAgents"
 Write-Host "  Target Project  : $targetPath"
 Write-Host ""
 
@@ -70,22 +85,21 @@ function Copy-Dir ([string]$srcDir, [string]$dstDir) {
 
 # 1. Copy Agents Template
 Write-Host "Step 1: Installing Agent Personalities and Schemas..."
-Copy-Dir (Join-Path $repoRoot "agents") (Join-Path $targetPath "agents")
+Copy-Dir $srcAgents (Join-Path $targetPath "agents")
 
 # 2. Copy World/Memory Template
 Write-Host ""
 Write-Host "Step 2: Installing World Memory and Mailbox Systems..."
-Copy-Dir (Join-Path $repoRoot "world") (Join-Path $targetPath "world")
+Copy-Dir $srcWorld (Join-Path $targetPath "world")
 
 # 3. Setup Settings File
 Write-Host ""
 Write-Host "Step 3: Configuring Master Settings..."
 $settingsDst = Join-Path $targetPath "SETTINGS.jsonc"
-$settingsSrc = Join-Path $repoRoot "SETTINGS.example.jsonc"
 if (Test-Path $settingsDst) {
     Write-Host "  [skipped]   SETTINGS.jsonc already exists"
 } else {
-    Copy-Item $settingsSrc $settingsDst
+    Copy-Item $srcSettings $settingsDst
     Write-Host "  [created]   SETTINGS.jsonc (default template copied)"
 }
 
@@ -95,7 +109,7 @@ Write-Host "Step 4: Writing AI Tool Integration Adapters..."
 
 # 4.a Claude CLI (CLAUDE.md)
 $claudeDst = Join-Path $targetPath "CLAUDE.md"
-$claudeSrc = Join-Path $repoRoot "adapters\claude-cli\CLAUDE.md"
+$claudeSrc = Join-Path $srcAdapters "claude-cli\CLAUDE.md"
 if (Test-Path $claudeSrc) {
     Copy-Item $claudeSrc $claudeDst -Force
     Write-Host "  [installed] CLAUDE.md (Claude CLI adapter)"
@@ -103,7 +117,7 @@ if (Test-Path $claudeSrc) {
 
 # 4.b VS Code Cline (.clinerules)
 $clineDst = Join-Path $targetPath ".clinerules"
-$clineSrc = Join-Path $repoRoot "adapters\cline\.clinerules"
+$clineSrc = Join-Path $srcAdapters "cline\.clinerules"
 if (Test-Path $clineSrc) {
     Copy-Item $clineSrc $clineDst -Force
     Write-Host "  [installed] .clinerules (VS Code Cline adapter)"
@@ -111,7 +125,7 @@ if (Test-Path $clineSrc) {
 
 # 4.c Cursor (.cursorrules)
 $cursorDst = Join-Path $targetPath ".cursorrules"
-$cursorSrc = Join-Path $repoRoot "adapters\cursor\.cursorrules"
+$cursorSrc = Join-Path $srcAdapters "cursor\.cursorrules"
 if (Test-Path $cursorSrc) {
     Copy-Item $cursorSrc $cursorDst -Force
     Write-Host "  [installed] .cursorrules (Cursor editor adapter)"
@@ -119,13 +133,13 @@ if (Test-Path $cursorSrc) {
 
 # 4.d Antigravity / Gemini CLI (.antigravityrules and GEMINI.md)
 $antigravityDst = Join-Path $targetPath ".antigravityrules"
-$antigravitySrc = Join-Path $repoRoot "adapters\antigravity\.antigravityrules"
+$antigravitySrc = Join-Path $srcAdapters "antigravity\.antigravityrules"
 if (Test-Path $antigravitySrc) {
     Copy-Item $antigravitySrc $antigravityDst -Force
     Write-Host "  [installed] .antigravityrules (Antigravity CLI adapter)"
 }
 $geminiDst = Join-Path $targetPath "GEMINI.md"
-$geminiSrc = Join-Path $repoRoot "adapters\gemini-cli\GEMINI.md"
+$geminiSrc = Join-Path $srcAdapters "gemini-cli\GEMINI.md"
 if (Test-Path $geminiSrc) {
     Copy-Item $geminiSrc $geminiDst -Force
     Write-Host "  [installed] GEMINI.md (Gemini CLI adapter)"
@@ -135,7 +149,7 @@ if (Test-Path $geminiSrc) {
 $copilotDir = Join-Path $targetPath ".github"
 if (-not (Test-Path $copilotDir)) { New-Item -ItemType Directory -Path $copilotDir -Force | Out-Null }
 $copilotDst = Join-Path $copilotDir "copilot-instructions.md"
-$copilotSrc = Join-Path $repoRoot "adapters\github-copilot-local\.github\copilot-instructions.md"
+$copilotSrc = Join-Path $srcAdapters "github-copilot-local\.github\copilot-instructions.md"
 if (Test-Path $copilotSrc) {
     Copy-Item $copilotSrc $copilotDst -Force
     Write-Host "  [installed] .github/copilot-instructions.md (GitHub Copilot adapter)"

--- a/scripts/setup-team.sh
+++ b/scripts/setup-team.sh
@@ -2,11 +2,7 @@
 # Tritium Team -- Workflow Setup Bootstrapper (Bash)
 #
 # Sets up the Tritium Team workflow structure in a target repository.
-# Drops in the agents, world/memory layers, and configures adapter rules
-# for Claude CLI, VS Code Cline, Cursor, Antigravity, and GitHub Copilot.
-#
-# Usage:
-#   bash scripts/setup-team.sh --target /path/to/your-project
+# Drops in the agents, world/memory layers, and configures adapter rules.
 #
 
 set -euo pipefail
@@ -33,6 +29,20 @@ NC='\033[0m' # No Color
 # Resolve paths
 here="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$here/.." && pwd)"
+tritium_home="${TRITIUM_HOME:-$HOME/.tritium-team}"
+
+# Determine template directories dynamically
+if [ -d "$repo_root/agents" ]; then
+  src_agents="$repo_root/agents"
+  src_world="$repo_root/world"
+  src_settings="$repo_root/SETTINGS.example.jsonc"
+  src_adapters="$repo_root/adapters"
+else
+  src_agents="$tritium_home/templates/agents"
+  src_world="$tritium_home/templates/world"
+  src_settings="$tritium_home/templates/SETTINGS.example.jsonc"
+  src_adapters="$tritium_home/templates/adapters"
+fi
 
 if [ ! -d "$target" ]; then
   mkdir -p "$target"
@@ -43,7 +53,7 @@ echo -e ""
 echo -e "${CYAN}╔════════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${CYAN}║                  TRITIUM TEAM WORKFLOW INITIALIZER                 ║${NC}"
 echo -e "${CYAN}╚════════════════════════════════════════════════════════════════════╝${NC}"
-echo -e "  Source Template : ${GRAY}$repo_root${NC}"
+echo -e "  Source Templates: ${GRAY}$src_agents${NC}"
 echo -e "  Target Project  : ${GRAY}$target_path${NC}"
 echo -e ""
 
@@ -58,12 +68,9 @@ copy_dir() {
   
   mkdir -p "$dst"
   
-  # Copy files using find to respect exclude patterns
   find "$src" -type f | while read -r file; do
-    # Skip .bak files
     [[ "$file" == *.bak ]] && continue
     
-    # Calculate relative path
     rel="${file#$src/}"
     dest_file="$dst/$rel"
     dest_dir="$(dirname "$dest_file")"
@@ -85,21 +92,20 @@ copy_dir() {
 }
 
 # 1. Copy Agents Template
-echo -e "Step 1: Installing Agent Personalities & Schemas..."
-copy_dir "$repo_root/agents" "$target_path/agents"
+echo -e "Step 1: Installing Agent Personalities and Schemas..."
+copy_dir "$src_agents" "$target_path/agents"
 
 # 2. Copy World/Memory Template
-echo -e "\nStep 2: Installing World Memory & Mailbox Systems..."
-copy_dir "$repo_root/world" "$target_path/world"
+echo -e "\nStep 2: Installing World Memory and Mailbox Systems..."
+copy_dir "$src_world" "$target_path/world"
 
 # 3. Setup Settings File
 echo -e "\nStep 3: Configuring Master Settings..."
 settings_dst="$target_path/SETTINGS.jsonc"
-settings_src="$repo_root/SETTINGS.example.jsonc"
 if [ -f "$settings_dst" ]; then
   echo -e "  ${GRAY}[skipped]${NC}   SETTINGS.jsonc already exists"
 else
-  cp "$settings_src" "$settings_dst"
+  cp "$src_settings" "$settings_dst"
   echo -e "  ${GREEN}[created]${NC}   SETTINGS.jsonc (default template copied)"
 fi
 
@@ -107,37 +113,37 @@ fi
 echo -e "\nStep 4: Writing AI Tool Integration Adapters..."
 
 # 4.a Claude CLI (CLAUDE.md)
-if [ -f "$repo_root/adapters/claude-cli/CLAUDE.md" ]; then
-  cp -f "$repo_root/adapters/claude-cli/CLAUDE.md" "$target_path/CLAUDE.md"
+if [ -f "$src_adapters/claude-cli/CLAUDE.md" ]; then
+  cp -f "$src_adapters/claude-cli/CLAUDE.md" "$target_path/CLAUDE.md"
   echo -e "  ${GREEN}[installed]${NC} CLAUDE.md (Claude CLI adapter)"
 fi
 
 # 4.b VS Code Cline (.clinerules)
-if [ -f "$repo_root/adapters/cline/.clinerules" ]; then
-  cp -f "$repo_root/adapters/cline/.clinerules" "$target_path/.clinerules"
+if [ -f "$src_adapters/cline/.clinerules" ]; then
+  cp -f "$src_adapters/cline/.clinerules" "$target_path/.clinerules"
   echo -e "  ${GREEN}[installed]${NC} .clinerules (VS Code Cline adapter)"
 fi
 
 # 4.c Cursor (.cursorrules)
-if [ -f "$repo_root/adapters/cursor/.cursorrules" ]; then
-  cp -f "$repo_root/adapters/cursor/.cursorrules" "$target_path/.cursorrules"
+if [ -f "$src_adapters/cursor/.cursorrules" ]; then
+  cp -f "$src_adapters/cursor/.cursorrules" "$target_path/.cursorrules"
   echo -e "  ${GREEN}[installed]${NC} .cursorrules (Cursor editor adapter)"
 fi
 
-# 4.d Antigravity / Gemini CLI (.antigravityrules & GEMINI.md)
-if [ -f "$repo_root/adapters/antigravity/.antigravityrules" ]; then
-  cp -f "$repo_root/adapters/antigravity/.antigravityrules" "$target_path/.antigravityrules"
+# 4.d Antigravity / Gemini CLI (.antigravityrules and GEMINI.md)
+if [ -f "$src_adapters/antigravity/.antigravityrules" ]; then
+  cp -f "$src_adapters/antigravity/.antigravityrules" "$target_path/.antigravityrules"
   echo -e "  ${GREEN}[installed]${NC} .antigravityrules (Antigravity CLI adapter)"
 fi
-if [ -f "$repo_root/adapters/gemini-cli/GEMINI.md" ]; then
-  cp -f "$repo_root/adapters/gemini-cli/GEMINI.md" "$target_path/GEMINI.md"
+if [ -f "$src_adapters/gemini-cli/GEMINI.md" ]; then
+  cp -f "$src_adapters/gemini-cli/GEMINI.md" "$target_path/GEMINI.md"
   echo -e "  ${GREEN}[installed]${NC} GEMINI.md (Gemini CLI adapter)"
 fi
 
 # 4.e VS Code GitHub Copilot (.github/copilot-instructions.md)
 mkdir -p "$target_path/.github"
-if [ -f "$repo_root/adapters/github-copilot-local/.github/copilot-instructions.md" ]; then
-  cp -f "$repo_root/adapters/github-copilot-local/.github/copilot-instructions.md" "$target_path/.github/copilot-instructions.md"
+if [ -f "$src_adapters/github-copilot-local/.github/copilot-instructions.md" ]; then
+  cp -f "$src_adapters/github-copilot-local/.github/copilot-instructions.md" "$target_path/.github/copilot-instructions.md"
   echo -e "  ${GREEN}[installed]${NC} .github/copilot-instructions.md (GitHub Copilot adapter)"
 fi
 

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -108,21 +108,31 @@ foreach ($a in $agents) {
     }
 }
 
-$claudeOk = 0; $geminiOk = 0; $copilotOk = 0
-foreach ($a in $agents) {
-    $p1 = Join-Path $root "adapters/claude-cli/agents/$a.md"
-    if (Test-Path -LiteralPath $p1 -PathType Leaf) { $claudeOk++; Write-Ok "adapter claude-cli/agents/$a.md" }
-    else { Write-Fail "missing adapters/claude-cli/agents/$a.md" }
+$claudeOk = 0; $geminiOk = 0; $copilotOk = 0; $clineOk = 0; $cursorOk = 0; $antigravityOk = 0
 
-    $p2 = Join-Path $root "adapters/gemini-cli/agents/$a.md"
-    if (Test-Path -LiteralPath $p2 -PathType Leaf) { $geminiOk++; Write-Ok "adapter gemini-cli/agents/$a.md" }
-    else { Write-Fail "missing adapters/gemini-cli/agents/$a.md" }
+$p_claude = Join-Path $root "adapters/claude-cli/CLAUDE.md"
+if (Test-Path -LiteralPath $p_claude -PathType Leaf) { $claudeOk = 1; Write-Ok "adapter claude-cli/CLAUDE.md" }
+else { Write-Fail "missing adapters/claude-cli/CLAUDE.md" }
 
-    $cap = $a.Substring(0,1).ToUpper() + $a.Substring(1)
-    $p3 = Join-Path $root "adapters/github-copilot-local/.github/agents/$cap.agent.md"
-    if (Test-Path -LiteralPath $p3 -PathType Leaf) { $copilotOk++; Write-Ok "adapter github-copilot-local/.github/agents/$cap.agent.md" }
-    else { Write-Fail "missing adapters/github-copilot-local/.github/agents/$cap.agent.md" }
-}
+$p_gemini = Join-Path $root "adapters/gemini-cli/GEMINI.md"
+if (Test-Path -LiteralPath $p_gemini -PathType Leaf) { $geminiOk = 1; Write-Ok "adapter gemini-cli/GEMINI.md" }
+else { Write-Fail "missing adapters/gemini-cli/GEMINI.md" }
+
+$p_copilot = Join-Path $root "adapters/github-copilot-local/.github/copilot-instructions.md"
+if (Test-Path -LiteralPath $p_copilot -PathType Leaf) { $copilotOk = 1; Write-Ok "adapter github-copilot-local/.github/copilot-instructions.md" }
+else { Write-Fail "missing adapters/github-copilot-local/.github/copilot-instructions.md" }
+
+$p_cline = Join-Path $root "adapters/cline/.clinerules"
+if (Test-Path -LiteralPath $p_cline -PathType Leaf) { $clineOk = 1; Write-Ok "adapter cline/.clinerules" }
+else { Write-Fail "missing adapters/cline/.clinerules" }
+
+$p_cursor = Join-Path $root "adapters/cursor/.cursorrules"
+if (Test-Path -LiteralPath $p_cursor -PathType Leaf) { $cursorOk = 1; Write-Ok "adapter cursor/.cursorrules" }
+else { Write-Fail "missing adapters/cursor/.cursorrules" }
+
+$p_antigravity = Join-Path $root "adapters/antigravity/.antigravityrules"
+if (Test-Path -LiteralPath $p_antigravity -PathType Leaf) { $antigravityOk = 1; Write-Ok "adapter antigravity/.antigravityrules" }
+else { Write-Fail "missing adapters/antigravity/.antigravityrules" }
 
 # --- inbox CLI smoke test --------------------------------------------------
 $inboxStatus = 'SKIP'
@@ -199,7 +209,7 @@ switch ($pyStatus) {
 if ($gitVer) { Write-Host "- Git:     found $gitVer" } else { Write-Host '- Git:     MISSING' }
 Write-Host "- Mailboxes: $mailboxPresent/9 present"
 Write-Host "- Agent docs: $agentMdPresent/9 present"
-Write-Host "- Adapters: claude-cli $claudeOk/9, gemini-cli $geminiOk/9, copilot-local $copilotOk/9"
+Write-Host "- Adapters: claude-cli=$claudeOk, gemini-cli=$geminiOk, copilot-local=$copilotOk, cline=$clineOk, cursor=$cursorOk, antigravity=$antigravityOk"
 Write-Host "- Inbox CLI: $inboxStatus"
 Write-Host "- Ledger:  $ledgerStatus"
 Write-Host '- Optional integrations:'

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -122,21 +122,31 @@ _capitalize() {
     printf '%s%s' "$(printf '%s' "${s:0:1}" | tr '[:lower:]' '[:upper:]')" "${s:1}"
 }
 
-CLAUDE_OK=0; GEMINI_OK=0; COPILOT_OK=0
-for a in "${AGENTS[@]}"; do
-    f="$ROOT/adapters/claude-cli/agents/$a.md"
-    if [ -f "$f" ]; then CLAUDE_OK=$((CLAUDE_OK + 1)); _ok "adapter claude-cli/agents/$a.md"
-    else _fail "missing adapters/claude-cli/agents/$a.md"; fi
+CLAUDE_OK=0; GEMINI_OK=0; COPILOT_OK=0; CLINE_OK=0; CURSOR_OK=0; ANTIGRAVITY_OK=0
 
-    f="$ROOT/adapters/gemini-cli/agents/$a.md"
-    if [ -f "$f" ]; then GEMINI_OK=$((GEMINI_OK + 1)); _ok "adapter gemini-cli/agents/$a.md"
-    else _fail "missing adapters/gemini-cli/agents/$a.md"; fi
+f="$ROOT/adapters/claude-cli/CLAUDE.md"
+if [ -f "$f" ]; then CLAUDE_OK=1; _ok "adapter claude-cli/CLAUDE.md"
+else _fail "missing adapters/claude-cli/CLAUDE.md"; fi
 
-    cap="$(_capitalize "$a")"
-    f="$ROOT/adapters/github-copilot-local/.github/agents/$cap.agent.md"
-    if [ -f "$f" ]; then COPILOT_OK=$((COPILOT_OK + 1)); _ok "adapter github-copilot-local/.github/agents/$cap.agent.md"
-    else _fail "missing adapters/github-copilot-local/.github/agents/$cap.agent.md"; fi
-done
+f="$ROOT/adapters/gemini-cli/GEMINI.md"
+if [ -f "$f" ]; then GEMINI_OK=1; _ok "adapter gemini-cli/GEMINI.md"
+else _fail "missing adapters/gemini-cli/GEMINI.md"; fi
+
+f="$ROOT/adapters/github-copilot-local/.github/copilot-instructions.md"
+if [ -f "$f" ]; then COPILOT_OK=1; _ok "adapter github-copilot-local/.github/copilot-instructions.md"
+else _fail "missing adapters/github-copilot-local/.github/copilot-instructions.md"; fi
+
+f="$ROOT/adapters/cline/.clinerules"
+if [ -f "$f" ]; then CLINE_OK=1; _ok "adapter cline/.clinerules"
+else _fail "missing adapters/cline/.clinerules"; fi
+
+f="$ROOT/adapters/cursor/.cursorrules"
+if [ -f "$f" ]; then CURSOR_OK=1; _ok "adapter cursor/.cursorrules"
+else _fail "missing adapters/cursor/.cursorrules"; fi
+
+f="$ROOT/adapters/antigravity/.antigravityrules"
+if [ -f "$f" ]; then ANTIGRAVITY_OK=1; _ok "adapter antigravity/.antigravityrules"
+else _fail "missing adapters/antigravity/.antigravityrules"; fi
 
 # --- inbox CLI smoke test ---------------------------------------------------
 INBOX_STATUS="SKIP"
@@ -205,7 +215,7 @@ if [ -n "$GIT_VER" ]; then echo "- Git:     found $GIT_VER"
 else echo "- Git:     MISSING"; fi
 echo "- Mailboxes: $MAILBOX_PRESENT/9 present"
 echo "- Agent docs: $AGENT_MD_PRESENT/9 present"
-echo "- Adapters: claude-cli $CLAUDE_OK/9, gemini-cli $GEMINI_OK/9, copilot-local $COPILOT_OK/9"
+echo "- Adapters: claude-cli=$CLAUDE_OK, gemini-cli=$GEMINI_OK, copilot-local=$COPILOT_OK, cline=$CLINE_OK, cursor=$CURSOR_OK, antigravity=$ANTIGRAVITY_OK"
 echo "- Inbox CLI: $INBOX_STATUS"
 echo "- Ledger:  $LEDGER_STATUS"
 echo "- Optional integrations:"


### PR DESCRIPTION
This PR adds global template directories under ~/.tritium-team/templates/ during installation, lets the setup scripts resolve templates from there when run globally, and implements 'tritium init' and 'tritium setup' subcommands in the CLI.